### PR TITLE
Replace deprecated no_trailing_comma_in_list_call rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "conflict": {
         "php": "<7.4",
-        "friendsofphp/php-cs-fixer": "<3.0",
+        "friendsofphp/php-cs-fixer": "<3.11",
         "nunomaduro/larastan": "<0.6",
         "squizlabs/php_codesniffer": "<3.0",
         "phpmd/phpmd": "<2.0",

--- a/rules/php-cs-fixer.php
+++ b/rules/php-cs-fixer.php
@@ -42,7 +42,7 @@ return (new PhpCsFixer\Config())
         'no_short_bool_cast'                          => true,
         'no_singleline_whitespace_before_semicolons'  => true,
         'no_spaces_around_offset'                     => true,
-        'no_trailing_comma_in_list_call'              => true,
+        'no_trailing_comma_in_singleline'             => true,
         'no_unneeded_control_parentheses'             => true,
         'no_unused_imports'                           => true,
         'no_useless_else'                             => true,


### PR DESCRIPTION
`no_trailing_comma_in_list_call` is deprecated. Dient vervangen te worden met: `no_trailing_comma_in_singleline`

Zie: https://cs.symfony.com/doc/rules/control_structure/no_trailing_comma_in_list_call.html