### PR TITLE
Adjust reference to Larastan due to errors

### DIFF
--- a/rules/larastan.neon
+++ b/rules/larastan.neon
@@ -1,5 +1,5 @@
 includes:
-    - %rootDir%/../../nunomaduro/larastan/extension.neon
+    - ../../../nunomaduro/larastan/extension.neon
     - phpstan.neon
 
 parameters:


### PR DESCRIPTION
As far as I am aware the idea behind this rule is:
- Installing the tool using Phive in your preferred location (like the root of a project)
- Installing `nunumaduro/larastan` using composer
- Creating your own `phpstan.neon` file, referencing the `vendor/paqtcom/coding-standards/rules/larastan.neon`
- Running the tool referencing your own `phpstan.neon`

If you would do this, phpstan would look for `{INSTALLATION_LOCATION_OF_PHPSTAN}/../../nunumaduro/larastan/extension.neon` which would in almost no cases actually result in a valid location (due to PHPStan being installed in the main directory). This fixes it by making the `larastan.neon` reference the package using a relative path rather than an absolute path.