### PR TITLE
Update to new larastan organisation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": "<8.0",
         "friendsofphp/php-cs-fixer": "<3.11",
         "larastan/larastan": "<2.7.0",
-        "nunomaduro/larastan": "<2.7.0",
+        "nunomaduro/larastan": "*",
         "squizlabs/php_codesniffer": "<3.0",
         "phpmd/phpmd": "<2.0",
         "phpstan/phpstan": "<0.12.50"

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,12 @@
     "type": "library",
     "license": "GPL-3.0",
     "suggest": {
-        "nunomaduro/larastan": "Provides phpstan extension specifically aimed towards Laravel"
+        "larastan/larastan": "Provides phpstan extension specifically aimed towards Laravel"
     },
     "conflict": {
         "php": "<8.0",
         "friendsofphp/php-cs-fixer": "<3.11",
+        "larastan/larastan": "<2.7.0",
         "nunomaduro/larastan": "<2.7.0",
         "squizlabs/php_codesniffer": "<3.0",
         "phpmd/phpmd": "<2.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "conflict": {
         "php": "<7.4",
         "friendsofphp/php-cs-fixer": "<3.11",
-        "nunomaduro/larastan": "<0.6",
+        "nunomaduro/larastan": "<2.7.0",
         "squizlabs/php_codesniffer": "<3.0",
         "phpmd/phpmd": "<2.0",
         "phpstan/phpstan": "<0.12.50"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "nunomaduro/larastan": "Provides phpstan extension specifically aimed towards Laravel"
     },
     "conflict": {
-        "php": "<7.4",
+        "php": "<8.0",
         "friendsofphp/php-cs-fixer": "<3.11",
         "nunomaduro/larastan": "<2.7.0",
         "squizlabs/php_codesniffer": "<3.0",

--- a/rules/larastan.neon
+++ b/rules/larastan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../../nunomaduro/larastan/extension.neon
+    - ../../../larastan/larastan/extension.neon
     - phpstan.neon
 
 parameters:


### PR DESCRIPTION
Larastan is verplaatst naar een andere github/composer organisation vanaf 2.7.0: https://github.com/larastan/larastan/blob/2.x/UPGRADE.md

Bij het updaten van een project zijn we naar larastan 2.7.0 gegaan en klopt het pad naar larastan.neon niet meer.