### PR TITLE
Updated deprecated rule by using identifiers

### DIFF
--- a/rules/phpstan.neon
+++ b/rules/phpstan.neon
@@ -1,5 +1,8 @@
 parameters:
     level: max
 
-    checkMissingIterableValueType: false
     checkUnionTypes: true
+
+    ignoreErrors:
+           -
+               identifier: missingType.iterableValue


### PR DESCRIPTION
Updated checkMissingIterableValueType rule to make use of identifiers. Since in phpstan 1.11.0 it won't work anymore. You will get the following warning.

```
vendor/bin/phpstan analyse --memory-limit=2G
Note: Using configuration file /home/developer/projects/vrnapp/phpstan.neon.
⚠️  You're using a deprecated config option checkMissingIterableValueType ⚠️️

It's strongly recommended to remove it from your configuration file
and add the missing array typehints.

If you want to continue ignoring missing typehints from arrays,
add missingType.iterableValue error identifier to your ignoreErrors:

parameters:
        ignoreErrors:
                -
                        identifier: missingType.iterableValue
```

https://github.com/phpstan/phpstan/releases/tag/1.11.0