### PR TITLE
Add declare_strict_types to PhpCsFixer ruleset

### DIFF
--- a/rules/php-cs-fixer.php
+++ b/rules/php-cs-fixer.php
@@ -114,5 +114,6 @@ return (new PhpCsFixer\Config())
         'trailing_comma_in_multiline'                 => ['elements' => ['arrays']],
         'trim_array_spaces'                           => true,
         'whitespace_after_comma_in_array'             => true,
+        'declare_strict_types'                        => true,
     ])
     ->setLineEnding("\n");


### PR DESCRIPTION
Voegt de `declare_strict_types` rule toe aan `php-cs-fixer.php`.

Deze zorgt ervoor dat een php file altijd een `declare(strict_types=1);` bovenaan heeft staan.