### PR TITLE
php-cs-fixer: always add a trailing comma in multiline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "conflict": {
         "php": "<8.0",
-        "friendsofphp/php-cs-fixer": "<3.11",
+        "friendsofphp/php-cs-fixer": "<3.63",
         "larastan/larastan": "<2.7.0",
         "nunomaduro/larastan": "*",
         "squizlabs/php_codesniffer": "<3.0",

--- a/rules/php-cs-fixer.php
+++ b/rules/php-cs-fixer.php
@@ -111,7 +111,15 @@ return (new PhpCsFixer\Config())
         'single_class_element_per_statement'          => true,
         'space_after_semicolon'                       => true,
         'standardize_not_equals'                      => true,
-        'trailing_comma_in_multiline'                 => ['elements' => ['arrays']],
+        'trailing_comma_in_multiline'                 => [
+            'elements' => [
+                'arguments',
+                'array_destructuring',
+                'arrays',
+                'match',
+                'parameters',
+            ],
+        ],
         'trim_array_spaces'                           => true,
         'whitespace_after_comma_in_array'             => true,
         'declare_strict_types'                        => true,


### PR DESCRIPTION
Ik liep er tegen aan dat de trailing comma's bij multilines inconsistent zijn: je mag ze op dit moment weglaten of neerzetten. Dus als je dan een extra regel eronder wilt toevoegen moet je soms de comma toevoegen en soms niet. Hierbij dus een wijziging die de `trailing_comma_in_multiline` gaat forceren en automatisch gaat fixen. 

Deze rule werkt bij `php >= 8.0`, maar deze staat al goed in de in de conflicts van de composer.json. 

php cs fixer heeft nu een conflict met `<3.63` omdat de `array_destructuring` optie redelijk nieuw is.

1 nadeel, dat het in mijn ogen waard is: bij het updaten van de coding standards krijg je 1x een grote PR met alle nieuwe comma's (als je dit niet zelf al deed)